### PR TITLE
Feat/#40/matching result

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import Home from '../pages/Home';
 import Matching from '../pages/Matching';
 import MatchingSurvey from '../pages/Matching/Survey';
 import MatchingResult from '../pages/Matching/Result';
+import MatchingHistory from '../pages/Matching/History';
 import PlantDetail from '../pages/PlantDetail';
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
         <Route path="/auth" element={<AuthFlow />} />
         <Route path="/matching/survey" element={<MatchingSurvey />} />
         <Route path="/matching/result" element={<MatchingResult />} />
+        <Route path="/matching/history" element={<MatchingHistory />} />
         <Route path="/auth/google/callback" element={<AuthCallback />} />
         <Route path="/auth/enter-name" element={<EnterName />} />
         <Route path="*" element={<NotFound />} />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,7 @@ import MatchingSurvey from '../pages/Matching/Survey';
 import MatchingResult from '../pages/Matching/Result';
 import MatchingHistory from '../pages/Matching/History';
 import PlantDetail from '../pages/PlantDetail';
+import Encyclopedia from '../pages/Encyclopedia';
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/matching" element={<Matching />} />
+          <Route path="/encyclopedia" element={<Encyclopedia />} />
         </Route>
         <Route path="/plants/:plantId" element={<PlantDetail />} />
         <Route path="/auth" element={<AuthFlow />} />

--- a/src/pages/Encyclopedia/EncyclopediaCard.tsx
+++ b/src/pages/Encyclopedia/EncyclopediaCard.tsx
@@ -41,7 +41,7 @@ const EncyclopediaCard = ({ plant, onClick }: EncyclopediaCardProps) => {
           {`관리 ${plant.manageDifficulty}, ${plant.size}, 공기정화 ${plant.airPurification}`}
         </p>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center">
           <span
             className={`icon-xs-fill ${plant.isFavorite ? 'text-primary' : 'text-text-30'}`}
           >

--- a/src/pages/Encyclopedia/EncyclopediaCard.tsx
+++ b/src/pages/Encyclopedia/EncyclopediaCard.tsx
@@ -1,0 +1,59 @@
+import type { PlantCatalogItemResponse } from '../../shared/api';
+import Img from '../../assets/banner/banner1.svg';
+
+interface EncyclopediaCardProps {
+  plant: PlantCatalogItemResponse;
+  onClick?: () => void;
+}
+
+const formatFavoriteCount = (count: number): string => {
+  if (count >= 10000) {
+    const value = count / 10000;
+    return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)}만`;
+  }
+  if (count >= 1000) {
+    return `${Math.floor(count / 1000)}천`;
+  }
+  return String(count);
+};
+
+const EncyclopediaCard = ({ plant, onClick }: EncyclopediaCardProps) => {
+  return (
+    <li
+      onClick={onClick}
+      className="flex flex-col gap-12 cursor-pointer min-w-0"
+    >
+      <div className="relative w-full aspect-square rounded-8 bg-[#EEF2E6] overflow-hidden flex items-end justify-center">
+        <div className="w-[80%] h-[80%] flex items-center justify-center">
+          <img src={Img} alt={plant.plantKoreanName} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <p className="body-m">
+          <span className="font-bold text-text-10">{plant.plantKoreanName}</span>
+          <span className="label-s font-normal text-text-20">
+            ({plant.plantEnglishName})
+          </span>
+        </p>
+
+        <p className="label-s text-text-30 line-clamp-2">
+          {`관리 ${plant.manageDifficulty}, ${plant.size}, 공기정화 ${plant.airPurification}`}
+        </p>
+
+        <div className="flex items-center gap-2">
+          <span
+            className={`icon-xs-fill ${plant.isFavorite ? 'text-primary' : 'text-text-30'}`}
+          >
+            favorite
+          </span>
+          <span className="label-s text-text-30">
+            {formatFavoriteCount(plant.favoriteCount)}
+          </span>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default EncyclopediaCard;

--- a/src/pages/Encyclopedia/FilterModal.tsx
+++ b/src/pages/Encyclopedia/FilterModal.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import Dim from '../../shared/ui/dim';
+import Button from '../../shared/ui/button';
+import {
+  useFilterStore,
+  type PlantFilter,
+} from '../../shared/stores/filterStore';
+
+interface FilterSectionConfig {
+  key: keyof PlantFilter;
+  title: string;
+  options: { value: string; label: string }[];
+}
+
+const SECTIONS: FilterSectionConfig[] = [
+  {
+    key: 'manageDifficulty',
+    title: '관리난이도',
+    options: [
+      { value: '매우쉬움', label: '관리매우쉬움' },
+      { value: '쉬움', label: '관리쉬움' },
+      { value: '보통', label: '관리보통' },
+      { value: '어려움', label: '관리어려움' },
+    ],
+  },
+  {
+    key: 'airPurification',
+    title: '공기정화',
+    options: [
+      { value: '아주높음', label: '아주높음' },
+      { value: '높음', label: '높음' },
+      { value: '보통', label: '보통' },
+    ],
+  },
+  {
+    key: 'plantSize',
+    title: '식물크기',
+    options: [
+      { value: '소형', label: '소형' },
+      { value: '중형', label: '중형' },
+      { value: '대형', label: '대형' },
+    ],
+  },
+];
+
+interface RadioOptionProps {
+  selected: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+const RadioOption = ({ selected, label, onClick }: RadioOptionProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-6 px-6"
+    >
+      <span
+        className={`flex items-center justify-center w-[14px] h-[14px] rounded-full border ${
+          selected ? 'border-primary bg-primary' : 'border-stroke-10'
+        }`}
+      >
+        {selected && <span className="w-[6px] h-[6px] rounded-full bg-surface-10" />}
+      </span>
+      <p
+        className={`label-s ${selected ? 'text-text-20' : 'text-text-30'}`}
+      >
+        {label}
+      </p>
+    </button>
+  );
+};
+
+interface FilterSectionProps {
+  config: FilterSectionConfig;
+}
+
+const FilterSection = ({ config }: FilterSectionProps) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const value = useFilterStore((s) => s.draft[config.key]);
+  const setDraft = useFilterStore((s) => s.setDraft);
+
+  return (
+    <div className="flex flex-col w-full overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center justify-between w-full"
+      >
+        <p className="body-m !font-semibold text-text-20">{config.title}</p>
+        <span className="icon-s text-text-30 p-4">
+          {isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+        </span>
+      </button>
+      {isOpen && (
+        <div className="flex flex-col gap-8 py-12">
+          {config.options.map((option) => (
+            <RadioOption
+              key={option.value}
+              selected={value === option.value}
+              label={option.label}
+              onClick={() => setDraft(config.key, option.value)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FilterModal = () => {
+  const isOpen = useFilterStore((s) => s.isOpen);
+  const closeModal = useFilterStore((s) => s.closeModal);
+  const applyFilter = useFilterStore((s) => s.applyFilter);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <>
+      <Dim onClick={closeModal} />
+      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full flex flex-col gap-16 px-16 pt-16 pb-24 rounded-t-[14px] bg-surface-10 shadow-[0px_0px_8px_0px_rgba(132,137,148,0.2)] z-2000">
+        <div className="flex items-start justify-between w-full text-text-10">
+          <div className="flex items-center">
+            <span className="icon-s">filter_alt</span>
+            <p className="body-m !font-[600]">필터</p>
+          </div>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="icon-s text-text-10"
+            aria-label="필터 닫기"
+          >
+            close
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-6 px-8 w-full">
+          {SECTIONS.map((section) => (
+            <FilterSection key={section.key} config={section} />
+          ))}
+        </div>
+
+        <div className="w-full py-24">
+          <Button onClick={applyFilter}>적용하기</Button>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+};
+
+export default FilterModal;

--- a/src/pages/Encyclopedia/FilterModal.tsx
+++ b/src/pages/Encyclopedia/FilterModal.tsx
@@ -58,8 +58,8 @@ const RadioOption = ({ selected, label, onClick }: RadioOptionProps) => {
       className="flex items-center gap-6 px-6"
     >
       <span
-        className={`flex items-center justify-center w-[14px] h-[14px] rounded-full border ${
-          selected ? 'border-primary bg-primary' : 'border-stroke-10'
+        className={`flex items-center justify-center w-[14px] h-[14px] outline-offset-[-1px] rounded-full outline transition-all duration-100 ease-in-out ${
+          selected ? 'outline-primary outline-4 outline-offset-[-4px]' : 'outline-stroke-10'
         }`}
       >
         {selected && <span className="w-[6px] h-[6px] rounded-full bg-surface-10" />}
@@ -90,13 +90,13 @@ const FilterSection = ({ config }: FilterSectionProps) => {
         className="flex items-center justify-between w-full"
       >
         <p className="body-m !font-semibold text-text-20">{config.title}</p>
-        <span className="icon-s text-text-30 p-4">
-          {isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+        <span className={`icon-s text-text-30 p-4 transition-all duration-200 ease-in-out ${isOpen ? 'rotate-180' : 'rotate-0'}`} >
+          keyboard_arrow_down
         </span>
       </button>
-      {isOpen && (
-        <div className="flex flex-col gap-8 py-12">
-          {config.options.map((option) => (
+        <div className="flex flex-col gap-8 py-12 transition-all duration-500 ease-in-out">
+          {isOpen && 
+            config.options.map((option) => (
             <RadioOption
               key={option.value}
               selected={value === option.value}
@@ -105,7 +105,6 @@ const FilterSection = ({ config }: FilterSectionProps) => {
             />
           ))}
         </div>
-      )}
     </div>
   );
 };

--- a/src/pages/Encyclopedia/TabBar.tsx
+++ b/src/pages/Encyclopedia/TabBar.tsx
@@ -1,0 +1,38 @@
+export type EncyclopediaTab = 'all' | 'popular' | 'favorites';
+
+interface TabBarProps {
+  active: EncyclopediaTab;
+  onChange: (tab: EncyclopediaTab) => void;
+}
+
+const TABS: { key: EncyclopediaTab; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'popular', label: '인기식물' },
+  { key: 'favorites', label: '찜목록' },
+];
+
+const TabBar = ({ active, onChange }: TabBarProps) => {
+  return (
+    <div className="flex w-full border-b border-stroke-10">
+      {TABS.map((tab) => {
+        const isActive = active === tab.key;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onChange(tab.key)}
+            className={`flex-1 flex items-center justify-center px-16 py-8 label-m transition-colors ${
+              isActive
+                ? 'border-b border-primary text-text-highlight'
+                : 'text-text-30'
+            }`}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default TabBar;

--- a/src/pages/Encyclopedia/TabBar.tsx
+++ b/src/pages/Encyclopedia/TabBar.tsx
@@ -12,8 +12,14 @@ const TABS: { key: EncyclopediaTab; label: string }[] = [
 ];
 
 const TabBar = ({ active, onChange }: TabBarProps) => {
+  const activeIndex = TABS.findIndex((tab) => tab.key === active);
+
   return (
-    <div className="flex w-full border-b border-stroke-10">
+    <div className="relative flex w-full border-b border-stroke-10">
+      <div
+        className="pointer-events-none absolute -bottom-px left-0 h-px w-1/3 bg-primary transition-transform duration-300 ease-in-out"
+        style={{ transform: `translateX(${activeIndex * 100}%)` }}
+      />
       {TABS.map((tab) => {
         const isActive = active === tab.key;
         return (
@@ -21,10 +27,8 @@ const TabBar = ({ active, onChange }: TabBarProps) => {
             key={tab.key}
             type="button"
             onClick={() => onChange(tab.key)}
-            className={`flex-1 flex items-center justify-center px-16 py-8 label-m transition-colors ${
-              isActive
-                ? 'border-b border-primary text-text-highlight'
-                : 'text-text-30'
+            className={`flex-1 flex items-center justify-center px-16 py-8 label-m transition-colors duration-300 ease-in-out ${
+              isActive ? 'text-text-highlight' : 'text-text-30'
             }`}
           >
             {tab.label}

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -113,7 +113,9 @@ const Encyclopedia = () => {
             <EncyclopediaCard
               key={plant.plantId}
               plant={plant}
-              onClick={() => navigate(`/plants/${plant.plantId}`)}
+              onClick={() =>
+                navigate(`/plants/${plant.plantId}`, { state: { plant } })
+              }
             />
           ))}
         </ul>

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { PlantCatalogItemResponse } from '../../shared/api';
+import EncyclopediaCard from './EncyclopediaCard';
+import TabBar, { type EncyclopediaTab } from './TabBar';
+
+const MOCK_PLANTS: PlantCatalogItemResponse[] = [
+  {
+    plantId: '1',
+    plantKoreanName: '스투키',
+    plantEnglishName: 'Stucky',
+    size: '중형',
+    airPurification: '높음',
+    manageDifficulty: '쉬움',
+    isFavorite: false,
+    favoriteCount: 107,
+  },
+  {
+    plantId: '2',
+    plantKoreanName: '스투키',
+    plantEnglishName: 'Stucky',
+    size: '중형',
+    airPurification: '높음',
+    manageDifficulty: '쉬움',
+    isFavorite: true,
+    favoriteCount: 94000,
+  },
+  {
+    plantId: '3',
+    plantKoreanName: '스투키',
+    plantEnglishName: 'Stucky',
+    size: '중형',
+    airPurification: '높음',
+    manageDifficulty: '쉬움',
+    isFavorite: false,
+    favoriteCount: 9000,
+  },
+  {
+    plantId: '4',
+    plantKoreanName: '스투키',
+    plantEnglishName: 'Stucky',
+    size: '중형',
+    airPurification: '높음',
+    manageDifficulty: '쉬움',
+    isFavorite: false,
+    favoriteCount: 62,
+  },
+  {
+    plantId: '5',
+    plantKoreanName: '스투키',
+    plantEnglishName: 'Stucky',
+    size: '중형',
+    airPurification: '높음',
+    manageDifficulty: '쉬움',
+    isFavorite: true,
+    favoriteCount: 320,
+  },
+];
+
+const Encyclopedia = () => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<EncyclopediaTab>('all');
+
+  const visiblePlants = useMemo(() => {
+    if (activeTab === 'popular') {
+      return [...MOCK_PLANTS].sort((a, b) => b.favoriteCount - a.favoriteCount);
+    }
+    if (activeTab === 'favorites') {
+      return MOCK_PLANTS.filter((p) => p.isFavorite);
+    }
+    return MOCK_PLANTS;
+  }, [activeTab]);
+
+  return (
+    <main className="flex flex-col gap-24 p-20 pb-100">
+      <TabBar active={activeTab} onChange={setActiveTab} />
+
+      <section className="flex flex-col gap-8">
+        <div className="flex items-center justify-between px-6">
+          <span className="label-s text-text-20">총 {visiblePlants.length}개</span>
+          <div className="flex items-center text-text-30">
+            <span className="icon-xs">filter_alt</span>
+            <span className="label-s">필터</span>
+          </div>
+        </div>
+
+        <ul className="grid grid-cols-2 gap-x-8 gap-y-16">
+          {visiblePlants.map((plant) => (
+            <EncyclopediaCard
+              key={plant.plantId}
+              plant={plant}
+              onClick={() => navigate(`/plants/${plant.plantId}`)}
+            />
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+};
+
+export default Encyclopedia;

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { PlantCatalogItemResponse } from '../../shared/api';
+import { useFilterStore } from '../../shared/stores/filterStore';
 import EncyclopediaCard from './EncyclopediaCard';
 import TabBar, { type EncyclopediaTab } from './TabBar';
+import FilterModal from './FilterModal';
 
 const MOCK_PLANTS: PlantCatalogItemResponse[] = [
   {
@@ -60,28 +62,47 @@ const MOCK_PLANTS: PlantCatalogItemResponse[] = [
 const Encyclopedia = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<EncyclopediaTab>('all');
+  const applied = useFilterStore((s) => s.applied);
+  const openFilterModal = useFilterStore((s) => s.openModal);
 
   const visiblePlants = useMemo(() => {
+    let plants = MOCK_PLANTS;
     if (activeTab === 'popular') {
-      return [...MOCK_PLANTS].sort((a, b) => b.favoriteCount - a.favoriteCount);
+      plants = [...plants].sort((a, b) => b.favoriteCount - a.favoriteCount);
+    } else if (activeTab === 'favorites') {
+      plants = plants.filter((p) => p.isFavorite);
     }
-    if (activeTab === 'favorites') {
-      return MOCK_PLANTS.filter((p) => p.isFavorite);
+    if (applied.manageDifficulty) {
+      plants = plants.filter(
+        (p) => p.manageDifficulty === applied.manageDifficulty,
+      );
     }
-    return MOCK_PLANTS;
-  }, [activeTab]);
+    if (applied.airPurification) {
+      plants = plants.filter(
+        (p) => p.airPurification === applied.airPurification,
+      );
+    }
+    if (applied.plantSize) {
+      plants = plants.filter((p) => p.size === applied.plantSize);
+    }
+    return plants;
+  }, [activeTab, applied]);
 
   return (
-    <main className="flex flex-col gap-24 p-20 pb-100">
+    <main className="flex flex-col gap-24 p-20 pb-[100px]">
       <TabBar active={activeTab} onChange={setActiveTab} />
 
       <section className="flex flex-col gap-8">
         <div className="flex items-center justify-between px-6">
           <span className="label-s text-text-20">총 {visiblePlants.length}개</span>
-          <div className="flex items-center text-text-30">
+          <button
+            type="button"
+            onClick={openFilterModal}
+            className="flex items-center text-text-30"
+          >
             <span className="icon-xs">filter_alt</span>
             <span className="label-s">필터</span>
-          </div>
+          </button>
         </div>
 
         <ul className="grid grid-cols-2 gap-x-8 gap-y-16">
@@ -94,6 +115,8 @@ const Encyclopedia = () => {
           ))}
         </ul>
       </section>
+
+      <FilterModal />
     </main>
   );
 };

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -92,7 +92,7 @@ const Encyclopedia = () => {
   }, [activeTab, applied]);
 
   return (
-    <main className="flex flex-col gap-24 p-20 pb-[100px]">
+    <main className="flex flex-col gap-24 p-20">
       <TabBar active={activeTab} onChange={setActiveTab} />
 
       <section className="flex flex-col gap-8">

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { PlantCatalogItemResponse } from '../../shared/api';
 import { useFilterStore } from '../../shared/stores/filterStore';
+import { useHeader } from '../../shared/stores/headerStore';
 import EncyclopediaCard from './EncyclopediaCard';
 import TabBar, { type EncyclopediaTab } from './TabBar';
 import FilterModal from './FilterModal';
@@ -64,6 +65,8 @@ const Encyclopedia = () => {
   const [activeTab, setActiveTab] = useState<EncyclopediaTab>('all');
   const applied = useFilterStore((s) => s.applied);
   const openFilterModal = useFilterStore((s) => s.openModal);
+
+  useHeader('temp_preferences_eco', '식물도감');
 
   const visiblePlants = useMemo(() => {
     let plants = MOCK_PLANTS;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,10 +5,13 @@ import EatenCharacter from '../../assets/character/eaten.svg';
 import Title from '../../shared/ui/title.tsx';
 import { getPlants } from '../../shared/api';
 import type { PlantCatalogItemResponse } from '../../shared/api';
+import { useHeader } from '../../shared/stores/headerStore.ts';
 
 const Home = () => {
   const navigate = useNavigate();
   const [plantList, setPlantList] = useState<PlantCatalogItemResponse[]>([]);
+
+  useHeader('park', '정원');
 
   useEffect(() => {
     getPlants({ sort: 'LIKE_DESC', size: 10 })

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -21,7 +21,7 @@ const Home = () => {
       <article className="flex flex-col gap-16 p-16 bg-surface-20 rounded-8">
         <figure className="flex flex-col gap-6 p-8">
           <div className="flex justify-between p-8">
-            <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-6"> 
               <span className="body-s text-text-20">매칭하기</span>
               <span className="title-s text-text-10">맞춤 식물 큐레이션</span>
             </div>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -6,6 +6,7 @@ import Title from '../../shared/ui/title.tsx';
 import { getPlants } from '../../shared/api';
 import type { PlantCatalogItemResponse } from '../../shared/api';
 import { useHeader } from '../../shared/stores/headerStore.ts';
+import Banner from '../../widgets/banner.tsx';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -20,6 +21,7 @@ const Home = () => {
   }, []);
   return (
     <main className="flex flex-col gap-24 p-20">
+      <Banner/>
       {/*맞춤 식물 큐레이션*/}
       <article className="flex flex-col gap-16 p-16 bg-surface-20 rounded-8">
         <figure className="flex flex-col gap-6 p-8">
@@ -36,10 +38,10 @@ const Home = () => {
           </div>
         </figure>
         <div className="flex gap-8">
-          <button className=" body-s !font-[500] w-full px-16 py-12 rounded-max bg-primary text-text-on-primary">
+          <button className=" body-s !font-[500] w-full px-16 py-12 rounded-max bg-primary text-text-on-primary" onClick={() => navigate('/matching')}>
             매칭받기
           </button>
-          <button className="w-full px-16 py-12 rounded-max bg-surface-30 text-text-20">
+          <button className="w-full px-16 py-12 rounded-max bg-surface-30 text-text-20" onClick={() => navigate('/encyclopedia')}>
             식물 알아보기
           </button>
         </div>

--- a/src/pages/Matching/History/component/HistoryItem.tsx
+++ b/src/pages/Matching/History/component/HistoryItem.tsx
@@ -1,0 +1,23 @@
+interface HistoryItemProps {
+  title: string;
+  description: string;
+  onClick?: () => void;
+}
+
+const HistoryItem = ({ title, description, onClick }: HistoryItemProps) => {
+  return (
+    <li
+      onClick={onClick}
+      className="flex items-center w-full p-20 rounded-14 bg-surface-10 border border-stroke-10-trans cursor-pointer"
+    >
+      <div className="flex flex-col gap-6 items-start break-words">
+        <span className="body-s font-semibold text-text-10 leading-[22px]">
+          {title}
+        </span>
+        <span className="label-s text-text-30">{description}</span>
+      </div>
+    </li>
+  );
+};
+
+export default HistoryItem;

--- a/src/pages/Matching/History/index.tsx
+++ b/src/pages/Matching/History/index.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom';
+import DetailHeader from '../../../widgets/detailHeader.tsx';
+import Title from '../../../shared/ui/title.tsx';
+import HistoryItem from './component/HistoryItem.tsx';
+
+const MOCK_HISTORY = [
+  { id: 1, title: '햇빛이 잘드는 공간', description: '스투키, 몬스테라...' },
+  { id: 2, title: '햇빛이 잘드는 공간', description: '스투키, 몬스테라...' },
+  { id: 3, title: '햇빛이 잘드는 공간', description: '스투키, 몬스테라...' },
+  { id: 4, title: '햇빛이 잘드는 공간', description: '스투키, 몬스테라...' },
+  { id: 5, title: '햇빛이 잘드는 공간', description: '스투키, 몬스테라...' },
+];
+
+const MatchingHistory = () => {
+  const navigate = useNavigate();
+
+  return (
+    <main className="min-h-screen flex flex-col">
+      <DetailHeader onBack={() => navigate(-1)}>매칭기록</DetailHeader>
+      <section className="flex flex-1 flex-col gap-24 p-20">
+        <div className="flex flex-1 flex-col gap-16 py-16">
+          <Title icon="search_activity" title="기록" />
+          <ul className="flex flex-col gap-8 w-full">
+            {MOCK_HISTORY.map((item) => (
+              <HistoryItem
+                key={item.id}
+                title={item.title}
+                description={item.description}
+              />
+            ))}
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default MatchingHistory;

--- a/src/pages/Matching/Result/index.tsx
+++ b/src/pages/Matching/Result/index.tsx
@@ -2,7 +2,9 @@ import { useNavigate } from 'react-router-dom';
 import DetailHeader from '../../../widgets/detailHeader.tsx';
 import MatchingTitle from '../../../shared/matchingTitle.tsx';
 import Title from '../../../shared/ui/title.tsx';
+import Modal from '../../../shared/ui/modal.tsx';
 import ResultPlant from './components/ResultPlant.tsx';
+import { useModalStore } from '../../../shared/stores/modalStore.ts';
 import type {
   PlantRecommendationResponse,
   RecommendPlantsResponse,
@@ -44,11 +46,34 @@ const MOCK_RESULT: RecommendPlantsResponse = {
 
 const MatchingResult = () => {
   const navigate = useNavigate();
+  const openModal = useModalStore((state) => state.openModal);
+  const closeModal = useModalStore((state) => state.closeModal);
   const result = MOCK_RESULT;
+
+  const showExitModal = () => {
+    openModal({
+      useImage: false,
+      title: '나가기 전에!',
+      body: '식물 찜하기 하셨나요?',
+      label: '다시 매칭기록에서 찾아보실수 있어요!',
+      buttonAmount: 2,
+      buttons: [
+        { label: '더 둘러보기', onClick: () => closeModal() },
+        {
+          label: '나가기',
+          icon: 'meeting_room',
+          onClick: () => {
+            closeModal();
+            navigate('/');
+          },
+        },
+      ],
+    });
+  };
 
   return (
     <main className="min-h-screen flex flex-col">
-      <DetailHeader onBack={() => navigate('/')}>매칭결과</DetailHeader>
+      <DetailHeader onBack={showExitModal}>매칭결과</DetailHeader>
       <section className="flex flex-1 flex-col gap-24 p-20">
         <div className="flex flex-1 flex-col gap-24 pt-24">
           <MatchingTitle icon="bookmarks" textSize="title-l">
@@ -68,6 +93,7 @@ const MatchingResult = () => {
           </div>
         </div>
       </section>
+      <Modal />
     </main>
   );
 };

--- a/src/pages/Matching/Result/index.tsx
+++ b/src/pages/Matching/Result/index.tsx
@@ -1,141 +1,73 @@
-import { useEffect, useState } from 'react';
-
-import { useLocation, useNavigate } from 'react-router-dom';
-import Button from '../../../shared/ui/button.tsx';
-import type { SurveyAnswers } from '../Survey/types.ts';
+import { useNavigate } from 'react-router-dom';
+import DetailHeader from '../../../widgets/detailHeader.tsx';
+import MatchingTitle from '../../../shared/matchingTitle.tsx';
+import Title from '../../../shared/ui/title.tsx';
 import ResultPlant from './components/ResultPlant.tsx';
-import { recommendPlants } from '../../../shared/api/plants.ts';
 import type {
-  RecommendPlantsRequest,
+  PlantRecommendationResponse,
   RecommendPlantsResponse,
-  SunlightLevel,
-  VentilationLevel,
-  TemperatureLevel,
-  HumidityLevel,
-  CareLevelType,
-  ExperienceLevelType,
-  PlacementType,
 } from '../../../shared/api/types.ts';
 
-const SUNLIGHT_MAP: Record<string, SunlightLevel> = {
-  low: 'LOW',
-  mid: 'MEDIUM',
-  high: 'HIGH',
+const MOCK_PLANT_BASE: Omit<PlantRecommendationResponse, 'plantId' | 'score'> = {
+  plantName: '스투키',
+  plantEnglishName: 'Stucky',
+  reasons: [],
+  cautions: [],
+  representativeEnvironment: '실내',
+  secondaryEnvironmentTags: [],
+  airPurificationLevel: 'HIGH',
+  petSafetyLevel: 'SAFE',
+  difficultyLevel: 'EASY',
+  sizeCategory: 'MEDIUM',
+  recommendedPlacements: [],
+  description: '관리 쉬움, 중형, 공기정화 높음',
 };
 
-const VENTILATION_MAP: Record<string, VentilationLevel> = {
-  low: 'LOW',
-  mid: 'NORMAL',
-  high: 'HIGH',
+const MOCK_RESULT: RecommendPlantsResponse = {
+  historyId: 0,
+  saved: false,
+  representativeEnvironment: '실내',
+  secondaryEnvironmentTags: [],
+  plants: [
+    { ...MOCK_PLANT_BASE, plantId: 'mock-1', score: 107 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-2', score: 94000 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-3', score: 9000 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+    { ...MOCK_PLANT_BASE, plantId: 'mock-4', score: 62 },
+  
+  ],
 };
-
-const TEMPERATURE_MAP: Record<string, TemperatureLevel> = {
-  cool: 'LOW',
-  normal: 'NORMAL',
-  hot: 'HIGH',
-};
-
-const HUMIDITY_MAP: Record<string, HumidityLevel> = {
-  dry: 'LOW',
-  mid: 'NORMAL',
-  wet: 'HIGH',
-};
-
-const CARE_MAP: Record<string, CareLevelType> = {
-  easy: 'LOW',
-  mid: 'MEDIUM',
-  high: 'HIGH',
-};
-
-const EXPERIENCE_MAP: Record<string, ExperienceLevelType> = {
-  first: 'BEGINNER',
-  few: 'INTERMEDIATE',
-  expert: 'ADVANCED',
-};
-
-const PLACEMENT_MAP: Record<string, PlacementType> = {
-  bedroom: 'BEDROOM',
-  living: 'LIVING_ROOM',
-  kitchen: 'KITCHEN',
-  office: 'OFFICE',
-  desk: 'DESK',
-  bathroom: 'BATHROOM',
-  veranda: 'BALCONY',
-  window: 'WINDOW',
-};
-
-function buildRequest(answers: SurveyAnswers): RecommendPlantsRequest {
-  return {
-    sunlight: SUNLIGHT_MAP[answers.light ?? ''] ?? 'LOW',
-    ventilation: VENTILATION_MAP[answers.air ?? ''] ?? 'LOW',
-    temperature: TEMPERATURE_MAP[answers.temperature ?? ''] ?? 'LOW',
-    humidity: HUMIDITY_MAP[answers.humidity ?? ''] ?? 'LOW',
-    careLevel: CARE_MAP[answers.care ?? ''] ?? 'LOW',
-    experienceLevel: EXPERIENCE_MAP[answers.experience ?? ''] ?? 'BEGINNER',
-    hasPet: answers.pet === 'yes',
-    placement: PLACEMENT_MAP[answers.place ?? ''] ?? 'DESK',
-  };
-}
 
 const MatchingResult = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const answers = (location.state as { answers?: SurveyAnswers } | null)
-    ?.answers;
-
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<RecommendPlantsResponse | null>(null);
-
-  useEffect(() => {
-    if (!answers) return;
-
-    const fetch = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await recommendPlants(buildRequest(answers));
-        setResult(data);
-      } catch {
-        setError('추천 식물을 불러오는 데 실패했어요. 다시 시도해 주세요.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetch();
-  }, []);
+  const result = MOCK_RESULT;
 
   return (
-    <main className="min-h-screen flex flex-col p-20">
-      <h1 className="title-l py-24">매칭 결과</h1>
+    <main className="min-h-screen flex flex-col">
+      <DetailHeader onBack={() => navigate('/')}>매칭결과</DetailHeader>
+      <section className="flex flex-1 flex-col gap-24 p-20">
+        <div className="flex flex-1 flex-col gap-24 pt-24">
+          <MatchingTitle icon="bookmarks" textSize="title-l">
+            사용자님 장소에
+            <br />
+            알맞는 식물들을 찾았어요!
+          </MatchingTitle>
 
-      {loading && (
-        <div className="flex-1 flex items-center justify-center">
-          <p className="body-s text-text-30">추천 식물을 찾고 있어요...</p>
+          <div className="flex flex-1 flex-col gap-16 py-16">
+            <Title icon="yard" title="추천 식물" />
+
+            <ul className="grid grid-cols-2 gap-x-8 gap-y-12">
+              {result.plants.map((plant, index) => (
+                <ResultPlant key={plant.plantId} plant={plant} rank={index + 1} />
+              ))}
+            </ul>
+          </div>
         </div>
-      )}
-
-      {error && (
-        <div className="flex-1 flex items-center justify-center">
-          <p className="body-s text-red-500">{error}</p>
-        </div>
-      )}
-
-      {result && (
-        <div className="flex-1 flex flex-col gap-16">
-          <p className="body-s text-text-30">{result.representativeEnvironment}</p>
-          <ul className="grid grid-cols-2 gap-x-12 gap-y-24">
-            {result.plants.map((plant, index) => (
-              <ResultPlant key={plant.plantId} plant={plant} rank={index + 1} />
-            ))}
-          </ul>
-        </div>
-      )}
-
-      <div className="h-fit pt-24">
-        <Button onClick={() => navigate('/')}>홈으로</Button>
-      </div>
+      </section>
     </main>
   );
 };

--- a/src/pages/Matching/Result/index.tsx
+++ b/src/pages/Matching/Result/index.tsx
@@ -3,7 +3,7 @@ import DetailHeader from '../../../widgets/detailHeader.tsx';
 import MatchingTitle from '../../../shared/matchingTitle.tsx';
 import Title from '../../../shared/ui/title.tsx';
 import Modal from '../../../shared/ui/modal.tsx';
-import ResultPlant from './components/ResultPlant.tsx';
+import ResultPlant from '../../../shared/ui/ResultPlant.tsx';
 import { useModalStore } from '../../../shared/stores/modalStore.ts';
 import type {
   PlantRecommendationResponse,

--- a/src/pages/Matching/Survey/index.tsx
+++ b/src/pages/Matching/Survey/index.tsx
@@ -133,7 +133,7 @@ const MatchingSurvey = () => {
         <div className="flex gap-8 h-fit py-16">
           {!isFirst && (
             <div className="flex-1">
-            <Button onClick={handlePrev}>
+            <Button onClick={handlePrev} undo={true}>
               <span className="icon-s">chevron_backward</span>
               <span className="mr-12">이전으로</span>
             </Button>

--- a/src/pages/Matching/index.tsx
+++ b/src/pages/Matching/index.tsx
@@ -56,7 +56,7 @@ const Matching = () => {
   };
 
   return (
-    <main className="h-[calc(100vh-60px)] flex flex-col p-20 pb-[96px]">
+    <main className="h-full flex flex-col p-20">
       <article className="h-full flex flex-col justify-center items-center gap-24">
         <object type="image/svg+xml" data={Blink} width={161} height={200} />
         <div className="flex flex-col gap-8 py-12">

--- a/src/pages/Matching/index.tsx
+++ b/src/pages/Matching/index.tsx
@@ -3,11 +3,26 @@ import Button from '../../shared/ui/button.tsx';
 import Modal from '../../shared/ui/modal.tsx';
 import { useModalStore } from '../../shared/stores/modalStore.ts';
 import Blink from '../../assets/character/blink.svg';
+import { useHeader } from '../../shared/stores/headerStore.ts';
 
 const Matching = () => {
   const navigate = useNavigate();
   const openModal = useModalStore((state) => state.openModal);
   const closeModal = useModalStore((state) => state.closeModal);
+
+  useHeader('explore', '매칭', {
+    variant: 'highlight',
+    rightSlot: (
+      <button
+        type="button"
+        onClick={() => navigate('/matching/history')}
+        className="flex items-center justify-center p-8 rounded-max"
+        aria-label="매칭 기록"
+      >
+        <span className="icon-l text-text-30">search_activity</span>
+      </button>
+    ),
+  });
 
   const handleStart = () => {
     const saved = localStorage.getItem('matchingSurveyAnswers');

--- a/src/pages/PlantDetail/index.tsx
+++ b/src/pages/PlantDetail/index.tsx
@@ -1,8 +1,30 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { getPlantById, addFavorite, removeFavorite } from '../../shared/api';
-import type { PlantDetailResponse } from '../../shared/api';
+import type {
+  PlantCatalogItemResponse,
+  PlantDetailResponse,
+} from '../../shared/api';
 import Button from '../../shared/ui/button';
+
+const catalogToDetail = (
+  item: PlantCatalogItemResponse,
+): PlantDetailResponse => ({
+  plantId: item.plantId,
+  plantKoreanName: item.plantKoreanName,
+  plantEnglishName: item.plantEnglishName,
+  manageDifficulty: item.manageDifficulty,
+  size: item.size,
+  airPurification: item.airPurification,
+  isFavorite: item.isFavorite,
+  waterPeriod: '',
+  appropriateTemperature: '',
+  appropriateHumidity: '',
+  sunlightRequirements: '',
+  recommendedIndoorLocation: '',
+  petSafety: '',
+  description: '',
+});
 
 const difficultyLabel: Record<string, string> = {
   VERY_EASY: '관리쉬움',
@@ -14,12 +36,23 @@ const difficultyLabel: Record<string, string> = {
 const PlantDetail = () => {
   const { plantId } = useParams<{ plantId: string }>();
   const navigate = useNavigate();
-  const [plant, setPlant] = useState<PlantDetailResponse | null>(null);
-  const [loading, setLoading] = useState(true);
+  const location = useLocation();
+  const passedPlant = (
+    location.state as { plant?: PlantCatalogItemResponse } | null
+  )?.plant;
+  const [plant, setPlant] = useState<PlantDetailResponse | null>(
+    passedPlant && passedPlant.plantId === plantId
+      ? catalogToDetail(passedPlant)
+      : null,
+  );
+  const [loading, setLoading] = useState(
+    !(passedPlant && passedPlant.plantId === plantId),
+  );
   const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!plantId) return;
+    if (passedPlant && passedPlant.plantId === plantId) return;
     setLoading(true);
     getPlantById(plantId)
       .then((res) => setPlant(res))

--- a/src/shared/stores/filterStore.ts
+++ b/src/shared/stores/filterStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+export interface PlantFilter {
+  manageDifficulty: string | null;
+  airPurification: string | null;
+  plantSize: string | null;
+}
+
+const emptyFilter: PlantFilter = {
+  manageDifficulty: null,
+  airPurification: null,
+  plantSize: null,
+};
+
+interface FilterStore {
+  isOpen: boolean;
+  applied: PlantFilter;
+  draft: PlantFilter;
+  openModal: () => void;
+  closeModal: () => void;
+  setDraft: (key: keyof PlantFilter, value: string | null) => void;
+  applyFilter: () => void;
+}
+
+export const useFilterStore = create<FilterStore>((set) => ({
+  isOpen: false,
+  applied: { ...emptyFilter },
+  draft: { ...emptyFilter },
+  openModal: () =>
+    set((state) => ({ isOpen: true, draft: { ...state.applied } })),
+  closeModal: () => set({ isOpen: false }),
+  setDraft: (key, value) =>
+    set((state) => ({ draft: { ...state.draft, [key]: value } })),
+  applyFilter: () =>
+    set((state) => ({ isOpen: false, applied: { ...state.draft } })),
+}));

--- a/src/shared/stores/headerStore.ts
+++ b/src/shared/stores/headerStore.ts
@@ -1,0 +1,41 @@
+import { useEffect, type ReactNode } from 'react';
+import { create } from 'zustand';
+
+export type HeaderVariant = 'primary' | 'highlight';
+
+export interface HeaderConfig {
+  icon: string;
+  title: ReactNode;
+  rightSlot?: ReactNode;
+  variant?: HeaderVariant;
+}
+
+interface HeaderStore {
+  config: HeaderConfig | null;
+  setHeader: (config: HeaderConfig) => void;
+  resetHeader: () => void;
+}
+
+export const useHeaderStore = create<HeaderStore>((set) => ({
+  config: null,
+  setHeader: (config) => set({ config }),
+  resetHeader: () => set({ config: null }),
+}));
+
+interface UseHeaderOptions {
+  rightSlot?: ReactNode;
+  variant?: HeaderVariant;
+}
+
+export const useHeader = (
+  icon: string,
+  title: ReactNode,
+  options?: UseHeaderOptions,
+) => {
+  const setHeader = useHeaderStore((s) => s.setHeader);
+  const rightSlot = options?.rightSlot;
+  const variant = options?.variant;
+  useEffect(() => {
+    setHeader({ icon, title, rightSlot, variant });
+  }, [icon, title, rightSlot, variant, setHeader]);
+};

--- a/src/shared/ui/ResultPlant.tsx
+++ b/src/shared/ui/ResultPlant.tsx
@@ -1,5 +1,5 @@
-import type { PlantRecommendationResponse } from '../../../../shared/api/types';
-import Img from "../../../../assets/banner/banner1.svg"
+import type { PlantRecommendationResponse } from '../api/types';
+import Img from '../../assets/banner/banner1.svg'
 
 interface ResultPlantProps {
   plant: PlantRecommendationResponse;

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,14 +5,15 @@ interface ButtonProps {
   children: React.ReactNode;
   dimmed?: boolean;
   disabled?: boolean;
+  undo?: boolean;
 }
 
-const Button = ({ icon, children, onClick, dimmed, disabled }: ButtonProps) => {
+const Button = ({ icon, children, onClick, dimmed, disabled, undo }: ButtonProps) => {
   return (
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`h-full w-full p-16 flex justify-center gap-6 bg-primary rounded-14 text-text-on-primary ${dimmed || disabled ? ' opacity-50' : ''} ${disabled ? 'cursor-not-allowed' : ''}`}
+      className={`h-full w-full p-16 flex justify-center gap-6 rounded-14 ${dimmed || disabled ? ' opacity-50' : ''} ${disabled ? 'cursor-not-allowed' : ''} ${undo ? 'bg-surface-20 text-text-20' : 'bg-primary text-text-on-primary'}`}
       type="button"
     >
       {icon && <span className={'icon-s'}>{icon}</span>}

--- a/src/shared/ui/dim.tsx
+++ b/src/shared/ui/dim.tsx
@@ -1,7 +1,14 @@
-const Dim = () => {
-  return(
-    <div className=" h-full w-full fixed bottom-0 bg-surface-30/40 backdrop-blur-[4px] z-1000" />
-  );
+interface DimProps {
+  onClick?: () => void;
 }
+
+const Dim = ({ onClick }: DimProps) => {
+  return (
+    <div
+      onClick={onClick}
+      className="h-full w-full fixed bottom-0 bg-surface-30/40 backdrop-blur-[4px] z-1000"
+    />
+  );
+};
 
 export default Dim;

--- a/src/shared/ui/modalButton.tsx
+++ b/src/shared/ui/modalButton.tsx
@@ -11,7 +11,7 @@ const ModalButton = ({ index }: ModalButtonProps) => {
   if (!button) return null;
 
   return (
-    <Button icon={button.icon} onClick={button.onClick}>
+    <Button icon={button.icon} onClick={button.onClick} undo={index === 1 && true}>
       {button.label}
     </Button>
   );

--- a/src/widgets/bottomNav.tsx
+++ b/src/widgets/bottomNav.tsx
@@ -11,7 +11,7 @@ const BottomNav = () => {
   ];
 
   return (
-    <nav className="fixed bottom-0 flex h-fit w-dvw bg-surface-10 px-12 border-t border-t-stroke-10">
+    <nav className="flex h-fit w-full shrink-0 bg-surface-10 px-12 border-t border-t-stroke-10">
       {navItems.map((item) => {
         const isActive = location.pathname === item.path;
         return (

--- a/src/widgets/header.tsx
+++ b/src/widgets/header.tsx
@@ -1,15 +1,22 @@
-interface headerProps {
-  icon: string;
-  children: React.ReactNode;
-}
+import { useHeaderStore } from '../shared/stores/headerStore';
 
-const Header = ({ icon, children } : headerProps) => {
-  return(
-  	<header className="flex items-center gap-6 px-24 h-[3.75rem]">
-			<span className="icon-m text-primary">{icon}</span>
-      <h1 className="title-m text-primary">{children}</h1>
-		</header>
+const Header = () => {
+  const config = useHeaderStore((s) => s.config);
+  if (!config) return null;
+
+  const { icon, title, rightSlot, variant = 'primary' } = config;
+  const colorClass =
+    variant === 'highlight' ? 'text-text-highlight' : 'text-primary';
+
+  return (
+    <header className="flex items-center justify-between pl-24 pr-16 h-[3.75rem]">
+      <div className={`flex items-center gap-6 ${colorClass}`}>
+        <span className="icon-m">{icon}</span>
+        <h1 className="title-m">{title}</h1>
+      </div>
+      {rightSlot}
+    </header>
   );
-}
+};
 
 export default Header;

--- a/src/widgets/layout.tsx
+++ b/src/widgets/layout.tsx
@@ -4,9 +4,11 @@ import BottomNav from './bottomNav';
 
 const Layout = () => {
   return (
-    <section>
+    <section className="h-dvh flex flex-col">
       <Header />
-      <Outlet />
+      <div className="flex-1 overflow-y-auto no-scrollbar">
+        <Outlet />
+      </div>
       <BottomNav />
     </section>
   );


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #40

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 식물도감 페이지 추가: 전체/인기/즐겨찾기 탭으로 식물 탐색 가능
  * 필터 기능: 관리 난이도, 공기정화, 식물 크기별로 검색 결과 필터링
  * 매칭 기록 페이지 추가: 이전 매칭 결과 조회

* **개선**
  * 앱 네비게이션 구조 및 헤더 UI 개선
  * 식물 상세 페이지 로딩 성능 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Person-Green/Frontend-Client/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->