### PR TITLE
Feat/#44/plant list api

### DIFF
--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -137,6 +137,7 @@ export interface PlantCatalogItemResponse {
   plantId: string;
   plantKoreanName: string;
   plantEnglishName: string;
+  imageUrl?: string;
   size: string;
   airPurification: string;
   manageDifficulty: string;

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -155,6 +155,7 @@ export interface PlantDetailResponse {
   plantId: string;
   plantKoreanName: string;
   plantEnglishName: string;
+  imageUrl?: string;
   manageDifficulty: string;
   waterPeriod: string;
   appropriateTemperature: string;

--- a/src/pages/Encyclopedia/EncyclopediaCard.tsx
+++ b/src/pages/Encyclopedia/EncyclopediaCard.tsx
@@ -1,5 +1,9 @@
 import type { PlantCatalogItemResponse } from '../../entities';
 import NonePlantImage from '../../assets/plants/none.svg';
+import {
+  toAirPurificationLabel,
+  toDifficultyShort,
+} from '../../shared/lib/plantLabels';
 
 interface EncyclopediaCardProps {
   plant: PlantCatalogItemResponse;
@@ -41,7 +45,7 @@ const EncyclopediaCard = ({ plant, onClick }: EncyclopediaCardProps) => {
         </p>
 
         <p className="label-s text-text-30 line-clamp-2">
-          {`관리 ${plant.manageDifficulty}, ${plant.size}, 공기정화 ${plant.airPurification}`}
+          {`관리 ${toDifficultyShort(plant.manageDifficulty)}, ${plant.size}, 공기정화 ${toAirPurificationLabel(plant.airPurification)}`}
         </p>
 
         <div className="flex items-center">

--- a/src/pages/Encyclopedia/EncyclopediaCard.tsx
+++ b/src/pages/Encyclopedia/EncyclopediaCard.tsx
@@ -1,5 +1,5 @@
 import type { PlantCatalogItemResponse } from '../../entities';
-import Img from '../../assets/banner/banner1.svg';
+import NonePlantImage from '../../assets/plants/none.svg';
 
 interface EncyclopediaCardProps {
   plant: PlantCatalogItemResponse;
@@ -18,16 +18,19 @@ const formatFavoriteCount = (count: number): string => {
 };
 
 const EncyclopediaCard = ({ plant, onClick }: EncyclopediaCardProps) => {
+  const imageSrc =
+    plant.imageUrl && plant.imageUrl.trim() !== ''
+      ? plant.imageUrl
+      : NonePlantImage;
   return (
     <li
       onClick={onClick}
       className="flex flex-col gap-12 cursor-pointer min-w-0"
     >
-      <div className="relative w-full aspect-square rounded-8 bg-[#EEF2E6] overflow-hidden flex items-end justify-center">
-        <div className="w-[80%] h-[80%] flex items-center justify-center">
-          <img src={Img} alt={plant.plantKoreanName} />
-        </div>
-      </div>
+      <div
+        className="relative w-full aspect-square rounded-8 bg-[#EEF2E6] overflow-hidden bg-center bg-no-repeat bg-cover"
+        style={{ backgroundImage: `url(${imageSrc})` }}
+      />
 
       <div className="flex flex-col gap-6">
         <p className="body-m">

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -4,6 +4,10 @@ import { getPlants } from '../../entities';
 import type { PlantCatalogItemResponse } from '../../entities';
 import { useFilterStore } from '../../shared/stores/filterStore';
 import { useHeader } from '../../shared/stores/headerStore';
+import {
+  toAirPurificationLabel,
+  toDifficultyShort,
+} from '../../shared/lib/plantLabels';
 import EncyclopediaCard from './EncyclopediaCard';
 import TabBar, { type EncyclopediaTab } from './TabBar';
 import FilterModal from './FilterModal';
@@ -32,12 +36,12 @@ const Encyclopedia = () => {
     }
     if (applied.manageDifficulty) {
       plants = plants.filter(
-        (p) => p.manageDifficulty === applied.manageDifficulty,
+        (p) => toDifficultyShort(p.manageDifficulty) === applied.manageDifficulty,
       );
     }
     if (applied.airPurification) {
       plants = plants.filter(
-        (p) => p.airPurification === applied.airPurification,
+        (p) => toAirPurificationLabel(p.airPurification) === applied.airPurification,
       );
     }
     if (applied.plantSize) {

--- a/src/pages/Encyclopedia/index.tsx
+++ b/src/pages/Encyclopedia/index.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getPlants } from '../../entities';
 import type { PlantCatalogItemResponse } from '../../entities';
 import { useFilterStore } from '../../shared/stores/filterStore';
 import { useHeader } from '../../shared/stores/headerStore';
@@ -7,69 +8,23 @@ import EncyclopediaCard from './EncyclopediaCard';
 import TabBar, { type EncyclopediaTab } from './TabBar';
 import FilterModal from './FilterModal';
 
-const MOCK_PLANTS: PlantCatalogItemResponse[] = [
-  {
-    plantId: '1',
-    plantKoreanName: '스투키',
-    plantEnglishName: 'Stucky',
-    size: '중형',
-    airPurification: '높음',
-    manageDifficulty: '쉬움',
-    isFavorite: false,
-    favoriteCount: 107,
-  },
-  {
-    plantId: '2',
-    plantKoreanName: '스투키',
-    plantEnglishName: 'Stucky',
-    size: '중형',
-    airPurification: '높음',
-    manageDifficulty: '쉬움',
-    isFavorite: true,
-    favoriteCount: 94000,
-  },
-  {
-    plantId: '3',
-    plantKoreanName: '스투키',
-    plantEnglishName: 'Stucky',
-    size: '중형',
-    airPurification: '높음',
-    manageDifficulty: '쉬움',
-    isFavorite: false,
-    favoriteCount: 9000,
-  },
-  {
-    plantId: '4',
-    plantKoreanName: '스투키',
-    plantEnglishName: 'Stucky',
-    size: '중형',
-    airPurification: '높음',
-    manageDifficulty: '쉬움',
-    isFavorite: false,
-    favoriteCount: 62,
-  },
-  {
-    plantId: '5',
-    plantKoreanName: '스투키',
-    plantEnglishName: 'Stucky',
-    size: '중형',
-    airPurification: '높음',
-    manageDifficulty: '쉬움',
-    isFavorite: true,
-    favoriteCount: 320,
-  },
-];
-
 const Encyclopedia = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<EncyclopediaTab>('all');
+  const [plantList, setPlantList] = useState<PlantCatalogItemResponse[]>([]);
   const applied = useFilterStore((s) => s.applied);
   const openFilterModal = useFilterStore((s) => s.openModal);
 
   useHeader('temp_preferences_eco', '식물도감');
 
+  useEffect(() => {
+    getPlants({ size: 50 })
+      .then((res) => setPlantList(res.plants))
+      .catch((e) => console.error('식물도감 로딩 실패', e));
+  }, []);
+
   const visiblePlants = useMemo(() => {
-    let plants = MOCK_PLANTS;
+    let plants = plantList;
     if (activeTab === 'popular') {
       plants = [...plants].sort((a, b) => b.favoriteCount - a.favoriteCount);
     } else if (activeTab === 'favorites') {
@@ -89,7 +44,7 @@ const Encyclopedia = () => {
       plants = plants.filter((p) => p.size === applied.plantSize);
     }
     return plants;
-  }, [activeTab, applied]);
+  }, [activeTab, applied, plantList]);
 
   return (
     <main className="flex flex-col gap-24 p-20">

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -57,8 +57,10 @@ const Home = () => {
         <ul className="flex gap-16 overflow-x-scroll no-scrollbar -mx-20 px-20">
           {plantList.map((item) => (
             <PlantItem
+              key={item.plantId}
               name={item.plantKoreanName}
               description={`${item.size}, ${item.manageDifficulty}`}
+              imageUrl={item.imageUrl}
               onClick={() => navigate(`/plants/${item.plantId}`)}
             />
           ))}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -7,6 +7,7 @@ import { getPlants } from '../../entities';
 import type { PlantCatalogItemResponse } from '../../entities';
 import { useHeader } from '../../shared/stores/headerStore.ts';
 import Banner from '../../widgets/banner.tsx';
+import { toDifficultyLabel } from '../../shared/lib/plantLabels.ts';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -50,7 +51,7 @@ const Home = () => {
       <article className="flex flex-col gap-12 pb-20 ">
         <div className="flex justify-between items-center">
           <Title icon="nest_eco_leaf" title="인기식물" />
-          <span className="py-6 px-12 rounded-max label-s bg-surface-20 text-text-20">
+          <span className="py-6 px-12 rounded-max label-s bg-surface-20 text-text-20" onClick={() => navigate('/encyclopedia')}>
             전체보기
           </span>
         </div>
@@ -59,7 +60,7 @@ const Home = () => {
             <PlantItem
               key={item.plantId}
               name={item.plantKoreanName}
-              description={`${item.size}, ${item.manageDifficulty}`}
+              description={`${item.size}, ${toDifficultyLabel(item.manageDifficulty)}`}
               imageUrl={item.imageUrl}
               onClick={() => navigate(`/plants/${item.plantId}`)}
             />

--- a/src/pages/PlantDetail/index.tsx
+++ b/src/pages/PlantDetail/index.tsx
@@ -6,6 +6,7 @@ import type {
   PlantDetailResponse,
 } from '../../entities';
 import Button from '../../shared/ui/button';
+import NonePlantImage from '../../assets/plants/none.svg';
 
 const catalogToDetail = (
   item: PlantCatalogItemResponse,
@@ -13,6 +14,7 @@ const catalogToDetail = (
   plantId: item.plantId,
   plantKoreanName: item.plantKoreanName,
   plantEnglishName: item.plantEnglishName,
+  imageUrl: item.imageUrl,
   manageDifficulty: item.manageDifficulty,
   size: item.size,
   airPurification: item.airPurification,
@@ -106,8 +108,12 @@ const PlantDetail = () => {
       <div className="flex flex-col flex-1 overflow-hidden">
         <div className="flex flex-col gap-12 overflow-y-auto no-scrollbar flex-1 px-20 py-4">
           {/* 식물 이미지 */}
-          <div className="relative w-full aspect-square bg-surface-20 rounded-14 flex items-center justify-center overflow-hidden">
-            <span className="icon-l text-text-30 text-[80px]">potted_plant</span>
+          <div
+            className="relative w-full aspect-square bg-surface-20 rounded-14 flex items-center justify-center overflow-hidden bg-center bg-no-repeat bg-cover"
+            style={{
+              backgroundImage: `url(${plant.imageUrl && plant.imageUrl.trim() !== '' ? plant.imageUrl : NonePlantImage})`,
+            }}
+          >
             {/* 즐겨찾기 버튼 */}
             <button
               onClick={handleFavorite}

--- a/src/pages/PlantDetail/index.tsx
+++ b/src/pages/PlantDetail/index.tsx
@@ -7,6 +7,10 @@ import type {
 } from '../../entities';
 import Button from '../../shared/ui/button';
 import NonePlantImage from '../../assets/plants/none.svg';
+import {
+  toAirPurificationLabel,
+  toDifficultyLabel,
+} from '../../shared/lib/plantLabels';
 
 const catalogToDetail = (
   item: PlantCatalogItemResponse,
@@ -28,13 +32,6 @@ const catalogToDetail = (
   description: '',
 });
 
-const difficultyLabel: Record<string, string> = {
-  VERY_EASY: '관리쉬움',
-  EASY: '관리쉬움',
-  NORMAL: '보통',
-  HARD: '어려움',
-};
-
 const PlantDetail = () => {
   const { plantId } = useParams<{ plantId: string }>();
   const navigate = useNavigate();
@@ -54,11 +51,13 @@ const PlantDetail = () => {
 
   useEffect(() => {
     if (!plantId) return;
-    if (passedPlant && passedPlant.plantId === plantId) return;
-    setLoading(true);
+    const hasPassed = passedPlant && passedPlant.plantId === plantId;
+    if (!hasPassed) setLoading(true);
     getPlantById(plantId)
       .then((res) => setPlant(res))
-      .catch(() => setError(true))
+      .catch(() => {
+        if (!hasPassed) setError(true);
+      })
       .finally(() => setLoading(false));
   }, [plantId]);
 
@@ -147,7 +146,7 @@ const PlantDetail = () => {
               <div className="flex items-center gap-4 shrink-0">
                 <span className="icon-xs text-primary">verified_user</span>
                 <span className="label-s text-text-20">
-                  {difficultyLabel[plant.manageDifficulty] ?? plant.manageDifficulty}
+                  {toDifficultyLabel(plant.manageDifficulty)}
                 </span>
               </div>
             </div>

--- a/src/shared/lib/plantLabels.ts
+++ b/src/shared/lib/plantLabels.ts
@@ -1,0 +1,21 @@
+const DIFFICULTY_KO: Record<string, string> = {
+  VERY_EASY: '매우쉬움',
+  EASY: '쉬움',
+  NORMAL: '보통',
+  HARD: '어려움',
+};
+
+const AIR_PURIFICATION_KO: Record<string, string> = {
+  NORMAL: '보통',
+  HIGH: '높음',
+  VERY_HIGH: '아주높음',
+};
+
+export const toDifficultyShort = (value: string): string =>
+  DIFFICULTY_KO[value] ?? value;
+
+export const toDifficultyLabel = (value: string): string =>
+  DIFFICULTY_KO[value] ? `관리${DIFFICULTY_KO[value]}` : value;
+
+export const toAirPurificationLabel = (value: string): string =>
+  AIR_PURIFICATION_KO[value] ?? value;

--- a/src/shared/ui/plantItem.tsx
+++ b/src/shared/ui/plantItem.tsx
@@ -1,16 +1,29 @@
+import NonePlantImage from '../../assets/plants/none.svg';
+
 interface PlantInfo {
   name: string;
   description: string;
+  imageUrl?: string;
   onClick?: () => void;
 }
 
-const PlantItem = ({ name, description, onClick }: PlantInfo) => {
+const PlantItem = ({ name, description, imageUrl, onClick }: PlantInfo) => {
+  const src = imageUrl && imageUrl.trim() !== '' ? imageUrl : NonePlantImage;
   return (
     <li
       className="flex flex-col items-center cursor-pointer"
       onClick={onClick}
     >
-      <div className="w-[120px] h-[120px] bg-surface-30 rounded-8"></div>
+      <div className="w-[120px] h-[120px] bg-surface-30 rounded-8">
+      <img
+        src={src}
+        alt={name}
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).src = NonePlantImage;
+        }}
+        className="w-[120px] h-[120px] rounded-8 object-cover"
+      />
+      </div>
       <span className="body-s !font-[600] text-text-10">{name}</span>
       <span className="label-s text-text-20">{description}</span>
     </li>


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #44

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 식물 카탈로그 및 상세 페이지에서 실제 식물 이미지 표시 기능 추가
  * 식물 도감 페이지에서 API를 통한 동적 데이터 로딩 구현

* **개선사항**
  * 난이도 및 공기정화 라벨 표시 방식 개선
  * 이미지 로딩 실패 시 기본 이미지로 자동 대체되도록 처리
  * 인기 식물 섹션에서 전체보기 링크 동작 연결

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Person-Green/Frontend-Client/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->